### PR TITLE
add_rootuser(mysql)

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,5 +50,6 @@ test:
 production:
   <<: *default
   database: kobe-works_production
-  username: kobe-works
-  password: <%= ENV['KOBE-WORKS_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
#WHAT
サーバーでのMYSQLのユーザー変更

#WHY
サーバー上でMYSQLをルートユーザーで使用できるようにするため